### PR TITLE
CANivore: Add a warning for Debian Bookworm on ARM64

### DIFF
--- a/source/docs/canivore/canivore-setup.rst
+++ b/source/docs/canivore/canivore-setup.rst
@@ -20,7 +20,9 @@ Currently, the following systems are supported for CANivore development:
 
   - Ubuntu 20.04 or newer
 
-  - Debian Bullseye or newer
+  - Debian Bullseye
+
+.. warning:: On ARM64 devices, Debian Bookworm is not supported at this time. Raspberry Pi users should select a "legacy" OS version that runs on Debian Bullseye.
 
 .. note:: **Custom bit rates and CAN 2.0 are not supported at this time.** The parameters passed into SocketCAN are not applied by the firmware.
 


### PR DESCRIPTION
The CANivore kernel module fails to install on Debian Bookworm.
Here's how it looks rendered:
![image](https://github.com/CrossTheRoadElec/PhoenixPro-Documentation/assets/73118262/31e8216e-fa35-48a2-bd94-b8fdca7178fb)
