### PR TITLE
Remove references to beta

### DIFF
--- a/source/docs/installation/installation-frc.rst
+++ b/source/docs/installation/installation-frc.rst
@@ -32,11 +32,11 @@ Installing Phoenix 6 (FRC)
 
             Paste the following URL in WPILib VS Code :guilabel:`Install new libraries (online)`:
 
-            - ``https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-beta-latest.json``
+            - ``https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json``
 
             Additionally, v5 can safely installed alongside it by installing the v5 vendordep.
 
-            - ``https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2024-beta-latest.json``
+            - ``https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2024-latest.json``
 
             .. important:: Users utilizing only v5 devices still need the v6 vendordep added to their robot project.
 

--- a/source/docs/yearly-changes/yearly-changelog.rst
+++ b/source/docs/yearly-changes/yearly-changelog.rst
@@ -3,13 +3,11 @@ New for 2024
 
 The CTR Electronics development team has been hard at work expanding the Phoenix 6 API based on user feedback. We are proud to announce several exciting new features with this release!
 
-Firmware for the beta version of 2024 Phoenix 6 can be found by selecting "2024" instead of "2023" in the firmware selection menu.
+Firmware for the 2024 release of Phoenix 6 can be found by selecting "2024" in the firmware selection menu.
 
-The API vendordep for the 2024 beta is available under ``https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-beta-latest.json``.
+The API vendordep for 2024 is available under ``https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json``.
 
 Users will need to update both firmware and API to make use of these features.
-
-.. important:: The 2024 Beta of Phoenix 6 requires 2024 Beta FRC Software.  Find more information about the beta `here <https://github.com/wpilibsuite/2024Beta>`__.
 
 .. note:: This changelog is intended to highlight the major additions to the Phoenix 6 API. For a detailed list of changes and bug fixes, visit the `Phoenix changelog <https://api.ctr-electronics.com/changelog>`__.
 


### PR DESCRIPTION
This should be merged after the stable kickoff release. We should also cut a 2024-beta branch before merging this. 