### PR TITLE
Add CANcoder sensor coefficient to feature replacements

### DIFF
--- a/source/docs/migration/canbus-utilization.rst
+++ b/source/docs/migration/canbus-utilization.rst
@@ -6,7 +6,7 @@ CTR Electronics goes through great efforts to make our products efficient on CAN
 .. note:: Using Phoenix API will automatically start up a diagnostic server which adds a constant 0-5% total CAN bus utilization.
 
 .. list-table::
-   :widths: 25 25 25 25 25
+   :widths: 18 20 20 20 22
    :header-rows: 1
 
    * - Device

--- a/source/docs/migration/canbus-utilization.rst
+++ b/source/docs/migration/canbus-utilization.rst
@@ -1,9 +1,9 @@
 CAN Bus Utilization
 ===================
 
-CTR Electronics goes through great efforts to make our products efficient on CAN Bus bandwidth. This article highlights the average default bandwidth utilization of supported Phoenix 6 devices. Users should keep total CAN Bus utilization below 90% to prevent any unexpected behavior. Information on changing the default CAN update frequency is available in the :ref:`API documentation <docs/api-reference/api-usage/status-signals:changing update frequency>`.
+CTR Electronics goes through great efforts to make our products efficient on CAN bus bandwidth. This article highlights the average default bus utilization of supported Phoenix 6 devices. Users should keep total CAN bus utilization below 90% to prevent any unexpected behavior. Information on changing the default CAN update frequency is available in the :ref:`status signal <docs/api-reference/api-usage/status-signals:changing update frequency>` and :ref:`control request <docs/api-reference/api-usage/control-requests:changing update frequency>` documentation.
 
-.. note:: Using Phoenix API will automatically start up a diagnostics server which adds a constant 0-5% total CAN Bus utilization.
+.. note:: Using Phoenix API will automatically start up a diagnostic server which adds a constant 0-5% total CAN bus utilization.
 
 .. list-table::
    :widths: 25 25 25 25 25
@@ -13,7 +13,7 @@ CTR Electronics goes through great efforts to make our products efficient on CAN
      - Phoenix 5 (CAN 2.0)
      - Phoenix 6 (CAN 2.0)
      - Phoenix 5 (CAN FD)
-     - Phoenix 6 (CAN FD)
+     - Phoenix 6 (CAN FD) [1]_
 
    * - .. centered:: Talon FX
      - 4.7%
@@ -32,3 +32,5 @@ CTR Electronics goes through great efforts to make our products efficient on CAN
      - 3.1%
      - 2.5%
      - 1.3%
+
+.. [1] Phoenix 6 devices on CAN FD also increase the default update frequency of many status signals to 100 Hz.

--- a/source/docs/migration/migration-guide/feature-replacements-guide.rst
+++ b/source/docs/migration/migration-guide/feature-replacements-guide.rst
@@ -51,6 +51,11 @@ Integral Zone and Max Integral Accumulator
 
 Phoenix 6 automatically prevents integral windup in closed-loop controls. As a result, the Integral Zone and Max Integral Accumulator configs are no longer necessary and have been removed.
 
+CANcoder Sensor Coefficient and Units
+-------------------------------------
+
+In Phoenix 6, CANcoder does not support setting a custom sensor coefficient, unit string, and sensor time base. Instead, the CANcoder uses canonical units of rotations and rotations per second using the `C++ units library <https://docs.wpilib.org/en/stable/docs/software/basic-programming/cpp-units.html>`__.
+
 Features to Be Implemented
 --------------------------
 

--- a/source/docs/yearly-changes/yearly-changelog.rst
+++ b/source/docs/yearly-changes/yearly-changelog.rst
@@ -87,8 +87,8 @@ Swerve drive code is as easy as the following.
 
 .. important:: Swerve API requires all necessary swerve devices to be v6 devices. e.g. 4 drive TalonFX, 4 steer TalonFX, 1 Pigeon 2.0, 4 CANcoders.
 
-Signal Logging
-^^^^^^^^^^^^^^
+:doc:`Signal Logging </docs/api-reference/api-usage/signal-logging>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've added a comprehensive signal logger (`Java <https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/SignalLogger.html>`__, `C++ <https://api.ctr-electronics.com/phoenix6/release/cpp/classctre_1_1phoenix6_1_1_signal_logger.html>`__, `Python <https://api.ctr-electronics.com/phoenix6/release/python/autoapi/phoenix6/signal_logger/index.html>`__, `C# <https://api.ctr-electronics.com/phoenix6/release/csharp/html/T_CTRE_Phoenix6_SignalLogger.htm>`__) that provides a real-time capture of signals for supported devices. Signal logging can be useful for analysis of signals over a period of time. In applications, they can be useful for tuning PID gains, characterization of systems, analyzing latency on a system and much more. Did something unexpected happen in a match? Go back and check your logs to inspect positions, velocities, voltages, currents, temperatures, etc. Logging is automatic, and does not require choosing which signals you need captured ahead of time.
 
@@ -133,8 +133,8 @@ Additionally, the following new functions have been added.
 
   * Retrieves the actual update frequency of a given signal
 
-New Motion Magic® Controls
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+New :doc:`Motion Magic® Controls </docs/api-reference/device-specific/talonfx/motion-magic>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We have added a Motion Magic® Velocity control mode, which produces a motion profile in real-time for a velocity controller. This allows for smooth transitions between velocity setpoints. Additionally, we have added a Dynamic Motion Magic® control mode for our Pro CANivore users, which supports modifying the cruise velocity, acceleration, and jerk settings during motion.
 


### PR DESCRIPTION
We've had a lot of questions about this, so add a note about it to the migration guide's feature replacements section.
Also add more links to other software docs pages from the New for 2024 page.