### PR TITLE
Remove mentions of Tuner v1 being included in the offline installer

### DIFF
--- a/source/docs/tuner/device-details-page.rst
+++ b/source/docs/tuner/device-details-page.rst
@@ -55,7 +55,7 @@ Tuner X has improved firmware upgrading functionality by **automatically downloa
 
 Users can switch between firmware release years by selecting from the dropdown above the firmware selection.
 
-.. note:: The toggle between firmware years only affects online field-upgrades.
+.. note:: The toggle between firmware years only affects the firmware versions downloaded by Tuner X. Files selected using the "Browse" button are not affected.
 
 .. image:: images/swapping-pro-phoenix5.png
    :width: 70%

--- a/source/docs/tuner/index.rst
+++ b/source/docs/tuner/index.rst
@@ -4,7 +4,7 @@ Phoenix Tuner X
 What is Phoenix Tuner X?
 ------------------------
 
-Phoenix Tuner X is the companion application allowing you to configure, analyze, update and control your device. Phoenix Tuner X can be installed from the `Google Play Store <https://play.google.com/store/apps/details?id=com.ctre.phoenix_tuner>`__ and the `Microsoft Store <https://apps.microsoft.com/store/detail/phoenix-tuner/9NVV4PWDW27Z>`__.
+Phoenix Tuner X is the companion application allowing you to update, configure, analyze, and control your devices. Phoenix Tuner X can be installed from the `Microsoft Store <https://apps.microsoft.com/store/detail/phoenix-tuner/9NVV4PWDW27Z>`__ and the `Google Play Store <https://play.google.com/store/apps/details?id=com.ctre.phoenix_tuner>`__.
 
 Phoenix Tuner X supports Android (8.0+), Windows 10 (1903+), and Windows 11.
 

--- a/source/docs/tuner/index.rst
+++ b/source/docs/tuner/index.rst
@@ -6,7 +6,7 @@ What is Phoenix Tuner X?
 
 Phoenix Tuner X is the companion application allowing you to update, configure, analyze, and control your devices. Phoenix Tuner X can be installed from the `Microsoft Store <https://apps.microsoft.com/store/detail/phoenix-tuner/9NVV4PWDW27Z>`__ and the `Google Play Store <https://play.google.com/store/apps/details?id=com.ctre.phoenix_tuner>`__.
 
-Phoenix Tuner X supports Android (8.0+), Windows 10 (1903+), and Windows 11.
+Phoenix Tuner X supports Windows 10 (1903+), Windows 11, and Android (8.0+).
 
 .. important:: While CTR Electronics supports both Phoenix Tuner v1 and Phoenix Tuner X, certain features such as device licensing, Phoenix 6 Self Test, and improved field upgrading are only available in Phoenix Tuner X.
 

--- a/source/docs/tuner/index.rst
+++ b/source/docs/tuner/index.rst
@@ -4,13 +4,11 @@ Phoenix Tuner X
 What is Phoenix Tuner X?
 ------------------------
 
-.. note:: The legacy Phoenix Tuner v1 is still available for use and is installed as part of the Phoenix installer.
+Phoenix Tuner X is the companion application allowing you to configure, analyze, update and control your device. Phoenix Tuner X can be installed from the `Google Play Store <https://play.google.com/store/apps/details?id=com.ctre.phoenix_tuner>`__ and the `Microsoft Store <https://apps.microsoft.com/store/detail/phoenix-tuner/9NVV4PWDW27Z>`__.
 
-Phoenix Tuner is the companion application allowing you to configure, analyze, update and control your device. Users may choose to use either Phoenix Tuner v1 (included as part of the Phoenix Installer) or Phoenix Tuner X (`Android <https://play.google.com/store/apps/details?id=com.ctre.phoenix_tuner>`__, `Windows <https://apps.microsoft.com/store/detail/phoenix-tuner/9NVV4PWDW27Z>`__).
+Phoenix Tuner X supports Android (8.0+), Windows 10 (1903+), and Windows 11.
 
-Phoenix Tuner X supports Android 8.0+ and Windows 10 (1903+) and Windows 11.
-
-.. important:: While CTR Electronics supports both Phoenix Tuner v1 and Phoenix Tuner X, certain features such as device licensing and improved batch upgrading are only available in Phoenix Tuner X.
+.. important:: While CTR Electronics supports both Phoenix Tuner v1 and Phoenix Tuner X, certain features such as device licensing, Phoenix 6 Self Test, and improved field upgrading are only available in Phoenix Tuner X.
 
 .. tip:: Many UI elements contain hover tooltips. That means the user can hover over them with their mouse for a text explanation of what they do.
 


### PR DESCRIPTION
We've removed Tuner v1 from the offline installer and plan on including Tuner X instead in the future.
Also point people towards Tuner X since Tuner v1 has limited support with Phoenix 6.