### PR TITLE
Add brief section of migration guide for imports/includes/namespaces

### DIFF
--- a/source/docs/api-reference/api-usage/configuration.rst
+++ b/source/docs/api-reference/api-usage/configuration.rst
@@ -168,8 +168,9 @@ Configs can be applied to a device by calling ``apply()`` on the ``Configurator`
 Factory Default
 ~~~~~~~~~~~~~~~
 
-A newly-created ``Configuration`` object contains the default configuration values of a device.
-Passing this newly-created ``Configuration`` object to the device ``Configurator`` will factory default the device's configs.
+A newly-created ``Configuration`` object contains the default configuration values of a device. As a result, it is **unnecessary** to factory default a device before applying a modified device ``Configuration`` object.
+
+A device's configs can be explicitly restored to the factory defaults by passing a newly-created ``Configuration`` object to the device ``Configurator``.
 
 .. tab-set::
 

--- a/source/docs/migration/migration-guide/api-structure-guide.rst
+++ b/source/docs/migration/migration-guide/api-structure-guide.rst
@@ -102,8 +102,8 @@ Phoenix 6 uses a separate, simpler set of namespaces and packages from Phoenix 5
             .. code-block:: cpp
 
                // Phoenix 6 is in the ctre/phoenix6 headers
-               #include "ctre/phoenix6/hardware/CANcoder.hpp"
-               #include "ctre/phoenix6/hardware/TalonFX.hpp"
+               #include "ctre/phoenix6/CANcoder.hpp"
+               #include "ctre/phoenix6/TalonFX.hpp"
 
                // Phoenix 6 uses the ctre::phoenix6 namespace
                using namespace ctre::phoenix6;

--- a/source/docs/migration/migration-guide/api-structure-guide.rst
+++ b/source/docs/migration/migration-guide/api-structure-guide.rst
@@ -1,0 +1,126 @@
+API Structure
+=============
+
+Phoenix 6 uses a separate, simpler set of namespaces and packages from Phoenix 5.
+
+.. note:: For more information about the structure of Phoenix 6, see :doc:`/docs/api-reference/api-usage/api-overview`.
+
+.. list-table::
+   :width: 100%
+   :widths: 1 99
+
+   * - .. centered:: v5
+     - .. tab-set::
+
+         .. tab-item:: Java
+            :sync: Java
+
+            .. code-block:: Java
+
+               // Phoenix 5 is in the com.ctre.phoenix.* packages
+               import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+               import com.ctre.phoenix.motorcontrol.TalonFXConfiguration;
+               import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
+               import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
+               import com.ctre.phoenix.motorcontrol.TalonFXSimCollection;
+               import com.ctre.phoenix.sensors.CANCoderConfiguration;
+               import com.ctre.phoenix.sensors.WPI_CANCoder;
+
+               // WPI_* for WPILib integration
+               final WPI_TalonFX m_talonFX = new WPI_TalonFX(0);
+               final WPI_CANCoder m_cancoder = new WPI_CANCoder(0);
+
+               final TalonFXSimCollection m_talonFXSim = m_talonFX.getSimCollection();
+
+               final TalonFXConfiguration m_talonConfig = new TalonFXConfiguration();
+               final CANCoderConfiguration m_cancoderConfig = new CANCoderConfiguration();
+
+               TalonFXInvertType m_talonFXInverted = TalonFXInvertType.CounterClockwise;
+
+               m_talonFX.set(TalonFXControlMode.PercentOutput, 0);
+
+         .. tab-item:: C++
+            :sync: C++
+
+            .. code-block:: cpp
+
+               // Phoenix 5 is in the ctre/phoenix headers
+               #include "ctre/phoenix/motorcontrol/can/WPI_TalonFX.h"
+               #include "ctre/phoenix/sensors/WPI_CANCoder.h"
+
+               // Phoenix 5 uses the ctre::phoenix namespace
+               using namespace ctre::phoenix;
+
+               // WPI_* for WPILib integration
+               motorcontrol::can::WPI_TalonFX m_talonFX{0};
+               sensors::WPI_CANCoder m_cancoder{0};
+
+               motorcontrol::TalonFXSimCollection& m_talonFXSim{m_talonFX.GetSimCollection()};
+
+               motorcontrol::TalonFXConfiguration m_talonConfig{};
+               sensors::CANCoderConfiguration m_cancoderConfig{};
+
+               motorcontrol::TalonFXInvertType m_talonFXInverted{motorcontrol::TalonFXInvertType::CounterClockwise};
+
+               m_talonFX.Set(motorcontrol::TalonFXControlMode::PercentOutput, 0);
+
+   * - .. centered:: v6
+     - .. tab-set::
+
+         .. tab-item:: Java
+            :sync: Java
+
+            .. code-block:: java
+
+               // Phoenix 6 is in the com.ctre.phoenix6.* packages
+               import com.ctre.phoenix6.configs.CANcoderConfiguration;
+               import com.ctre.phoenix6.configs.TalonFXConfiguration;
+               import com.ctre.phoenix6.controls.DutyCycleOut;
+               import com.ctre.phoenix6.hardware.CANcoder;
+               import com.ctre.phoenix6.hardware.TalonFX;
+               import com.ctre.phoenix6.signals.InvertedValue;
+               import com.ctre.phoenix6.sim.TalonFXSimState;
+
+               // All hardware classes already have WPILib integration
+               final TalonFX m_talonFX = new TalonFX(0);
+               final CANcoder m_cancoder = new CANcoder(0);
+
+               final TalonFXSimState m_talonFXSim = m_talonFX.getSimState();
+
+               final DutyCycleOut m_talonFXOut = new DutyCycleOut(0);
+
+               final TalonFXConfiguration m_talonFXConfig = new TalonFXConfiguration();
+               final CANcoderConfiguration m_cancoderConfig = new CANcoderConfiguration();
+
+               InvertedValue m_talonFXInverted = InvertedValue.CounterClockwise_Positive;
+
+               m_talonFX.setControl(m_talonFXOut);
+
+         .. tab-item:: C++
+            :sync: C++
+
+            .. code-block:: cpp
+
+               // Phoenix 6 is in the ctre/phoenix6 headers
+               #include "ctre/phoenix6/hardware/CANcoder.hpp"
+               #include "ctre/phoenix6/hardware/TalonFX.hpp"
+
+               // Phoenix 6 uses the ctre::phoenix6 namespace
+               using namespace ctre::phoenix6;
+
+               // now types are organized cleanly by namespace
+
+               // All hardware classes already have WPILib integration
+               hardware::TalonFX m_talonFX{0};
+               hardware::CANcoder m_cancoder{0};
+
+               sim::TalonFXSimState& m_talonFXSim{m_talonFX.GetSimState()};
+
+               controls::DutyCycleOut m_talonFXOut{0};
+
+               configs::TalonFXConfiguration m_talonFXConfig{};
+               configs::CANcoderConfiguration m_cancoderConfig{};
+
+               signals::InvertedValue m_talonFXInverted{signals::InvertedValue::CounterClockwise_Positive};
+
+               m_talonFX.SetControl(m_talonFXOut);

--- a/source/docs/migration/migration-guide/configuration-guide.rst
+++ b/source/docs/migration/migration-guide/configuration-guide.rst
@@ -47,30 +47,34 @@ Applying Configs
 
             .. code-block:: java
 
+               var talonFXConfigs = new TalonFXConfiguration();
+
                // set slot 0 gains
-               var slot0Configs = new Slot0Configs();
+               var slot0Configs = talonFXConfigs.Slot0;
                slot0Configs.kV = 0.12;
                slot0Configs.kP = 0.11;
                slot0Configs.kI = 0.5;
                slot0Configs.kD = 0.001;
 
-               // apply gains, 50 ms total timeout
-               m_talonFX.getConfigurator().apply(slot0Configs, 0.050);
+               // apply all configs, 50 ms total timeout
+               m_talonFX.getConfigurator().apply(talonFXConfigs, 0.050);
 
          .. tab-item:: C++
             :sync: C++
 
             .. code-block:: cpp
 
+               configs::TalonFXConfiguration talonFXConfigs{};
+
                // set slot 0 gains
-               configs::Slot0Configs slot0Configs{};
+               configs::Slot0Configs& slot0Configs = talonFXConfigs.Slot0;
                slot0Configs.kV = 0.12;
                slot0Configs.kP = 0.11;
                slot0Configs.kI = 0.5;
                slot0Configs.kD = 0.001;
 
-               // apply gains, 50 ms total timeout
-               m_talonFX.GetConfigurator().Apply(slot0Configs, 50_ms);
+               // apply all configs, 50 ms total timeout
+               m_talonFX.GetConfigurator().Apply(talonFXConfigs, 50_ms);
 
 Factory Defaulting Configs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -87,7 +91,7 @@ Factory Defaulting Configs
 
             .. code-block:: Java
 
-               // user must remember to factory default if they configure devices in code
+               // user must remember to explicitly factory default if they configure devices in code
                m_motor.configFactoryDefault();
 
          .. tab-item:: C++
@@ -95,7 +99,7 @@ Factory Defaulting Configs
 
             .. code-block:: cpp
 
-               // user must remember to factory default if they configure devices in code
+               // user must remember to explicitly factory default if they configure devices in code
                m_motor.ConfigFactoryDefault();
 
    * - .. centered:: v6
@@ -106,8 +110,11 @@ Factory Defaulting Configs
 
             .. code-block:: Java
 
-               // any unmodified configs in a configuration object are *automatically* factory-defaulted;
-               // user can perform a full factory default by passing a new device configuration object
+               // Any unmodified configs in a configuration object are *automatically* factory-defaulted.
+               // As a result, factory-defaulting before applying configs is *unnecessary* when using a
+               // full device configuration object, such as TalonFXConfiguration.
+
+               // Users can perform a full factory default by passing a new device configuration object.
                m_motor.getConfigurator().apply(new TalonFXConfiguration());
 
          .. tab-item:: C++
@@ -115,9 +122,12 @@ Factory Defaulting Configs
 
             .. code-block:: cpp
 
-               // any unmodified configs in a configuration object are *automatically* factory-defaulted;
-               // user can perform a full factory default by passing a new device configuration object
-               m_motor.GetConfigurator().Apply(TalonFXConfiguration{});
+               // Any unmodified configs in a configuration object are *automatically* factory-defaulted;
+               // As a result, factory-defaulting before applying configs is *unnecessary* when using a
+               // full device configuration object, such as TalonFXConfiguration.
+
+               // Users can perform a full factory default by passing a new device configuration object.
+               m_motor.GetConfigurator().Apply(configs::TalonFXConfiguration{});
 
 Retrieving Configs
 ------------------

--- a/source/docs/migration/migration-guide/configuration-guide.rst
+++ b/source/docs/migration/migration-guide/configuration-guide.rst
@@ -49,7 +49,7 @@ Applying Configs
 
                var talonFXConfigs = new TalonFXConfiguration();
 
-               // set slot 0 gains
+               // set slot 0 gains and leave every other config factory-default
                var slot0Configs = talonFXConfigs.Slot0;
                slot0Configs.kV = 0.12;
                slot0Configs.kP = 0.11;
@@ -66,7 +66,7 @@ Applying Configs
 
                configs::TalonFXConfiguration talonFXConfigs{};
 
-               // set slot 0 gains
+               // set slot 0 gains and leave every other config factory-default
                configs::Slot0Configs& slot0Configs = talonFXConfigs.Slot0;
                slot0Configs.kV = 0.12;
                slot0Configs.kP = 0.11;

--- a/source/docs/migration/migration-guide/feature-replacements-guide.rst
+++ b/source/docs/migration/migration-guide/feature-replacements-guide.rst
@@ -44,7 +44,7 @@ In Phoenix 5, users could configure the TalonFX to clear its sensor position (i.
 Velocity Measurement Period/Window
 ----------------------------------
 
-In Phoenix 6, the velocity rolling average window in Talon FX and CANcoder has been replaced with a Kalman filter, resulting in a less noisy velocity signal with a minimal impact on latency. As a result, the velocity measurement period/window configs are no longer necessary in Phoenix 6 and have been removed.
+In Phoenix 6, the velocity rolling average window in Talon FX and CANcoder has been replaced with a Kalman filter, resulting in a less noisy velocity signal with a minimal impact on latency (~1 ms). As a result, the velocity measurement period/window configs are no longer necessary in Phoenix 6 and have been removed.
 
 Integral Zone and Max Integral Accumulator
 ------------------------------------------

--- a/source/docs/migration/migration-guide/index.rst
+++ b/source/docs/migration/migration-guide/index.rst
@@ -3,6 +3,9 @@ API Migration
 
 This section serves as a "cheat sheet" of commonly-used functions in Phoenix 5 and their equivalents in Phoenix 6.
 
+- :doc:`api-structure-guide`
+   - General structure of the Phoenix 6 namespaces and packages
+
 - :doc:`configuration-guide`
    - Configuring device configs in robot code
 
@@ -22,6 +25,7 @@ This section serves as a "cheat sheet" of commonly-used functions in Phoenix 5 a
    :maxdepth: 1
    :hidden:
 
+   api-structure-guide
    configuration-guide
    status-signals-guide
    control-requests-guide


### PR DESCRIPTION
Phoenix 6 uses the com.ctre.phoenix6.* packages and the ctre/phoenix6 headers and organizes types differently from Phoenix 5.

Also improves the configuration documentation to emphasize that explicit factory defaults are unnecessary, as unmodified configs in a device Configuration object are factory defaulted.