### PR TITLE
Add documentation to check self test LEDs for hardware fault

### DIFF
--- a/source/docs/hardware-reference/cancoder/index.rst
+++ b/source/docs/hardware-reference/cancoder/index.rst
@@ -128,7 +128,7 @@ Status Light Reference
                 <td><div class='ledGroup'><div class='led' ontime='300' offtime='300' oncolor='red' offcolor='orange'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='green'></div></div></td>

--- a/source/docs/hardware-reference/cancoder/index.rst
+++ b/source/docs/hardware-reference/cancoder/index.rst
@@ -128,7 +128,7 @@ Status Light Reference
                 <td><div class='ledGroup'><div class='led' ontime='300' offtime='300' oncolor='red' offcolor='orange'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='green'></div></div></td>

--- a/source/docs/hardware-reference/candi/index.rst
+++ b/source/docs/hardware-reference/candi/index.rst
@@ -91,7 +91,7 @@ CANdi seamlessly integrates digital signals into existing CAN bus networks, simp
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/candi/index.rst
+++ b/source/docs/hardware-reference/candi/index.rst
@@ -91,7 +91,7 @@ CANdi seamlessly integrates digital signals into existing CAN bus networks, simp
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/canrange/index.rst
+++ b/source/docs/hardware-reference/canrange/index.rst
@@ -101,7 +101,7 @@ CANrange is a CAN-enabled Time-of-Flight distance measurement sensor. This produ
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/canrange/index.rst
+++ b/source/docs/hardware-reference/canrange/index.rst
@@ -101,7 +101,7 @@ CANrange is a CAN-enabled Time-of-Flight distance measurement sensor. This produ
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/pigeon2/index.rst
+++ b/source/docs/hardware-reference/pigeon2/index.rst
@@ -124,7 +124,7 @@ Status Light Reference
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/pigeon2/index.rst
+++ b/source/docs/hardware-reference/pigeon2/index.rst
@@ -124,7 +124,7 @@ Status Light Reference
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/talonfx/index.rst
+++ b/source/docs/hardware-reference/talonfx/index.rst
@@ -224,7 +224,7 @@ Status Light Reference
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/talonfx/index.rst
+++ b/source/docs/hardware-reference/talonfx/index.rst
@@ -224,7 +224,7 @@ Status Light Reference
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/talonfxs/index.rst
+++ b/source/docs/hardware-reference/talonfxs/index.rst
@@ -166,7 +166,7 @@ Supported Motors
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>

--- a/source/docs/hardware-reference/talonfxs/index.rst
+++ b/source/docs/hardware-reference/talonfxs/index.rst
@@ -166,7 +166,7 @@ Supported Motors
                                           <div class='led' ontime='300' offtime='300' oncolor='orange' offcolor='red'></div></div></td>
                 <td>Alternate Red/Orange</td>
                 <td>Damaged Hardware.</td>
-                <td>Use Tuner X Self Test to confirm the LEDs, then contact CTRE.</td>
+                <td>Use Tuner X Self Test to confirm the LEDs and that the hardware fault is set, then contact CTRE</td>
             </tr>
             <tr>
                 <td><div class='ledGroup'><div class='led' ontime='0' offtime='0' oncolor='black' offcolor='black'></div>


### PR DESCRIPTION
We may also want to clearly mention that blipping between red and orange is typically intermittent bad CAN bus, but I'm not sure where.